### PR TITLE
Add proof of concept, GitHub for Visual Studio integration

### DIFF
--- a/PReview/PReview.csproj
+++ b/PReview/PReview.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.14.0.23107\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.14.0.23107\build\Microsoft.VSSDK.BuildTools.props')" />
+  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.14.3.25420\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.14.3.25420\build\Microsoft.VSSDK.BuildTools.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -98,7 +98,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
@@ -297,10 +299,10 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.14.0.23107\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.14.0.23107\build\Microsoft.VSSDK.BuildTools.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.14.0.23107\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.14.0.23107\build\Microsoft.VSSDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.14.3.25420\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.14.3.25420\build\Microsoft.VSSDK.BuildTools.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.14.3.25420\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.14.3.25420\build\Microsoft.VSSDK.BuildTools.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.14.0.23107\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.14.0.23107\build\Microsoft.VSSDK.BuildTools.targets')" />
+  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.14.3.25420\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.14.3.25420\build\Microsoft.VSSDK.BuildTools.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/PReview/packages.config
+++ b/PReview/packages.config
@@ -19,7 +19,7 @@
   <package id="Microsoft.VisualStudio.Threading" version="14.0.50702" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Utilities" version="14.0.23107" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Validation" version="14.0.50702" targetFramework="net452" />
-  <package id="Microsoft.VSSDK.BuildTools" version="14.0.23107" targetFramework="net452" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.BuildTools" version="14.3.25420" targetFramework="net452" developmentDependency="true" />
   <package id="MvvmLightLibs" version="5.2.0.0" targetFramework="net452" />
   <package id="VSSDK.CoreUtility" version="12.0.4" targetFramework="net452" />
   <package id="VSSDK.CoreUtility.12" version="12.0.4" targetFramework="net452" />


### PR DESCRIPTION
Hi Laurent,

I love the work you've done on GitDiffMargin. When I was looking at that, I noticed you'd also started the PReview project. 😄 

This PR is a very simple proof of concept hack that lets PReview know which PR has been checked out using the PR functionality in GitHub for Visual Studio. All it does is expose the diff URL via some AppDomain data:
```
var diffUrl = (string)AppDomain.CurrentDomain.GetData("PReview.diff.url");
```

I also needed to update one of the NuGet packages to build/run with VS2015 R3.

To make it work you will need to use a similarly hacked branch of GitHubVS:
https://github.com/jcansdale/VisualStudio/tree/PReview-integration-hack


Try try it, do the following:

1. Install these pre-built VSIX files: [PReviewGitHub.zip](https://github.com/laurentkempe/PReview/files/763253/PReviewGitHub.zip)
2. Open the PReview.sln from this repo.
3. On the Team Explorer window, select Pull Requests.
![image](https://cloud.githubusercontent.com/assets/11719160/22778504/1c576d84-eeaf-11e6-828f-ec8eaf750e6e.png)
4. On the GitHub tool window, sellect this PR:
![image](https://cloud.githubusercontent.com/assets/11719160/22778571/534723f2-eeaf-11e6-929a-ff913a3fac73.png)
5. Checkout the PR:
![image](https://cloud.githubusercontent.com/assets/11719160/22778602/6eeeb08e-eeaf-11e6-9e85-f48f2afa7a8e.png)
6. Click on the Pull Request Filter option in Solution Explorer:
![image](https://cloud.githubusercontent.com/assets/11719160/22778677/baa4a646-eeaf-11e6-9ed2-012e46a222ee.png)
7. Woohoo! Super basic integration with the GitHub extension for Visual Studio! 😉 

Note, this won't currently work with a private repo,

I'd be interested to know what information you would like from the PReview end?

I'm guessing knowing the PR target branch would be more useful? You could then generate the patch/diff file without needing to know the .diff URL (I'm assuming).

At the moment *some* branches are tagged with the PR # the `.git\config` file like this:
```
[branch "pr/734-pull-request-sorting"]
	remote = StanleyGoldman
	ghfvs-pr = 734
```

Maybe the target branch could also be added there? That way GitHubVS wouldn't even need to be running for PReview to find the PR details. Something like this:

```
[branch "pr/734-pull-request-sorting"]
	remote = StanleyGoldman
	ghfvs-pr = 734
	ghfvs-pr-target-branch = target-branch-for-PR
```

I'd be interested to hear your thoughts. 😄 

Cheers,
Jamie.